### PR TITLE
swap fields in AdsNotificationHeader to fit to Windows version

### DIFF
--- a/AdsLib/AdsDef.h
+++ b/AdsLib/AdsDef.h
@@ -372,11 +372,11 @@ struct AdsNotificationAttrib {
  * @brief This structure is also passed to the callback function.
  */
 struct AdsNotificationHeader {
-    /** Contains a 64-bit value representing the number of 100-nanosecond intervals since January 1, 1601 (UTC). */
-    uint64_t nTimeStamp;
-
     /** Handle for the notification. Is specified when the notification is defined. */
     uint32_t hNotification;
+
+    /** Contains a 64-bit value representing the number of 100-nanosecond intervals since January 1, 1601 (UTC). */
+    uint64_t nTimeStamp;
 
     /** Number of bytes transferred. */
     uint32_t cbSampleSize;


### PR DESCRIPTION
Adresses issue https://github.com/MrLeeh/pyads/issues/37 which shows incompatibility between Windows Ads library and Linux Ads library. Change has been tested with pyads.